### PR TITLE
Add a Literate.jl notebook.

### DIFF
--- a/notebooks/SimSLR.jl
+++ b/notebooks/SimSLR.jl
@@ -1,0 +1,232 @@
+#=
+## Simulation of simple linear regression estimates
+
+To illustrate some of the capabilities of `DrWatson` for simulations we consider a simple example of simulating the parameter estimates from a simple linear regression model.
+
+In the second part of the workshop we will consider data from an experiment on the effects of sleep deprivation on reaction time.
+For each subject in the study we will assume a simple linear regression model,
+```math
+y_i = a*x_i + b + \epsilon_i,\; i = 1,\dots,10,\;\epsilon_i\sim\mathcal{N}(0,\sigma^2)
+```
+for their $i$th reaction time, $y_i$, as a function of the number of days of sleep deprivation, $x_i$.
+
+For subject `S334` the estimates of $a$ and $b$ are approximately $a=12.25$ ms/day and $b=240.16$ ms.
+An estimate of the residual standard deviation is $s=8.55$ ms, which we will use as the value of $\sigma$ in our simulation.
+
+For all the subjects, the days of sleep deprivation are from 0 to 9.
+
+First establish the `DrWatson` environment
+=#
+using DrWatson
+
+# and attach other packages to be used
+
+using Arrow, LinearAlgebra, Random, PrettyTables
+#=
+## Parameter tuples
+
+These parameter values are incorporated into a _named tuple_
+=#
+pars = (a = 12.25, b = 240.16, σ = 8.55, x = 0:9);
+typeof(pars)
+#=
+A Julia `NamedTuple` is similar to a named list in R except that the names are _symbols_ (the symbol 'a' is written ':a') and the types of the values are part of the tuple type itself.
+In `DrWatson` a simulation function typically takes a parameter tuple which is immediately _unpacked_ by calling the `@unpack` macro.
+A parameter tuple can also be used to generate a meaningful file name under which to save the results of a simulation.
+=#
+savename(pars, "arrow")  # file name for an Arrow file of results from these parameters
+#=
+## Generating a response and estimating parameters
+
+A simple function to generate a response is
+=#
+function oneresp(pars)
+    @unpack a, b, σ, x = pars  # expand the name/value pairs
+    a .* x .+ b .+ σ * randn(length(x))
+end;
+oneresp(pars)
+
+#=
+A call to `randn(n)` generates an independent sample of size `n` from a standard normal distribution.
+We scale these values by σ and add this "noise" to the assumed "true" response, `a * x + b`.
+
+In Julia the "dots" ('.') before an operator like '+' or '\*' cause the operation to be broadcast over arrays.
+
+### Reproducible "random" responses
+
+It is often convenient (like when you are debugging) to be able to reproduce the "random" numbers that were generated.
+To allow for this we will define another `oneresp` method that allows for a random number generator to be passed to it. 
+=#
+function oneresp(rng::AbstractRNG, pars::NamedTuple)
+    @unpack a, b, σ, x = pars
+    a .* x .+ b .+ σ .* randn(rng, length(x))
+end;
+rng = MersenneTwister(42);   # initialize a random number generator
+oneresp(rng, pars)
+#-
+y = oneresp(MersenneTwister(42), pars)  # reproduce those results
+
+#=
+### Estimates from a single sample
+
+The easiest way to obtain the least squares estimates is by building the model matrix and using the "backslash" operator, '\'.
+=#
+X = hcat(ones(10), 0:9)
+#-
+coef = X \ y
+
+# And $s^2$, the estimated residual variance, is
+
+s² = sum(abs2, y .- X * coef) / (size(X, 1) - size(X, 2))
+
+#=
+(`abs2(x)` returns `x*x` when `x` is a real (as in, non-complex) number.)
+
+### Simulating N parameter estimates
+
+At this point we can extend `oneresp` to do the calculations and return a NamedTuple
+=#
+
+function onepars(rng::AbstractRNG, pars::NamedTuple)
+    @unpack a, b, σ, x = pars
+    X = hcat(ones(length(x)), x)
+    n, p = size(X)
+    y = a .* x .+ b .+ σ .* randn(rng, n)
+    coef = X \ y
+    (slope = last(coef), intercept = first(coef), s² = sum(abs2, y .- X * coef)/(n - p))
+end
+onepars(MersenneTwister(42), pars)
+
+# To generate a sample of these parameter estimates we first initialize a random number generator then create a vector of evaluations of `onepars`.
+
+rng = MersenneTwister(6354789);
+samp = [onepars(rng, pars) for i in 1:100];
+samp[1:10]  # first 10 values
+
+#=
+(The construction with the `for` specification within the brackets is called a _comprehension_. It also exists in Python.)
+
+It may seem like a waste to repeat the names for each result but, in fact, the names are only stored once for this vector.
+=#
+
+typeof(samp)
+
+#=
+A vector of `NamedTuple`s is a row-oriented `Table`, as defined inthe `Tables` package.
+A column-oriented table, such as a `DataFrame`, could be a `NamedTuple` of vectors.
+Both types can be shown with `pretty_table` from the `PrettyTables` package.
+=#
+
+pretty_table(samp)
+#=
+## Tuning the simulation
+
+So, this approach works and produces simulated values that behave as expected.
+
+However, we are repeating a lot of effort for each evaluation of the simulation loop.
+At each iteration we create the same model matrix (of the same size) and the fixed part of the response, $\mathbf{y}$.
+And in the background the expression `X \ y` will copy `X` and `y` and decompose the copy of `X` into a "QR" decomposition.
+
+As is true in many languages, we can avoid many of these steps with enough effort in Julia.
+However, unlike other languages like R or Python, we do not need to "drop down" to a compiled language like C or C++ to take advantage of the low-level features in Julia.
+The magic of Julia is that the language offers you such a wide range of capabilities from high level to very low level using the same tools throughout.
+
+An optimized version of a simulation function could look like
+=#
+
+function simslr(rng::AbstractRNG, pars, N)
+    @unpack a, b, σ, x = pars
+    qrfac = qr!(hcat(ones(length(x)), x))
+    n, p = size(qrfac)
+    Qt = qrfac.Q'
+    R = UpperTriangular(qrfac.R)
+    y₀ = convert(Vector{eltype(qrfac)}, a .* x .+ b)
+    y = similar(y₀)
+    cv = view(y, 1:p)     # view of the part of Q'y defining the coefficients
+    rv = view(y, (p+1):n) # view of the part of Q'y defining the residuals
+    map(1:N) do i
+        for j in axes(y, 1)
+            y[j] = y₀[j] + σ * randn(rng)
+        end
+        lmul!(Qt, y)
+        ldiv!(R, cv)
+        (slope = y[2], intercept = y[1], s² = sum(abs2, rv)/(n - p))
+    end
+end
+
+# To ensure that it works
+
+rng = MersenneTwister(6354789);
+samp2 = simslr(rng, pars, 100);
+pretty_table(samp2)
+
+#=
+A superficial comparison shows that the two samples are similar.
+A more detailed comparison, say by converting each of them to `DataFrame`s and using `isapprox`, would show they are the same samples.
+
+However, their execution times and the amount of storage used when generating, say, 10,000 samples are very different.
+=#
+
+rng = MersenneTwister(6354789);
+@time [onepars(rng, pars) for i in 1:10_000];
+#-
+rng = MersenneTwister(6354789);
+@time simslr(rng, pars, 10_000);
+
+#=
+The optimized version is over 10 times faster and requires much less memory and fewer allocations than the original version.
+
+The savings in memory allocations and usage come from the fact that all of the memory to be used, except for the storage of the result itself, is allocated before entering the simulation loop and re-used within the loop.
+Unlike R, Julia allows a function to modify its arguments if they are composite structures like vectors.
+It is customary to append "!" to the names of such _mutating_ functions, like `lmul!` (multiply, in-place, on the left) and `ldiv!` (divide, in-place, on the left).
+
+Also, in the simulation loop itself, the vector `y` is filled in with the fixed part of the response plus the random noise in an inner loop.
+This is the exact opposite of the programming style favored in R and Python where loops are avoided at all cost.
+In Julia a loop is a perfectly fine way of programming an iterative operation; there is no need to perform contorsions to "vectorize" operations.
+
+## Saving results
+
+A common workflow is to perform a simulation saving the results so they can be analyzed separately.
+Typically (though not in this example) the simulation can take a long time and may be done unattended whereas the analysis requires interaction with the data.
+
+The Apache Arrow format, which can be written and read using the [`Arrow.jl` package](https://github.com/JuliaData/Arrow.jl), is a versatile, efficient, and cross-platform format for storing tabular data.
+Arrow files written with the `arrow` package for R or with the `pyarrow` package for Python can be read by `Arrow.jl`.
+(Going the other direction can be problematic with R as not all the number types used in Julia can be represented in R.)
+=#
+
+rng = MersenneTwister(42);
+mkpath(datadir("simulations"));  # in case the directory does not exist
+fnm = Arrow.write(datadir("simulations", savename(pars, "arrow")), simslr(rng, pars, 50_000))
+
+# The process of writing the Arrow file converts the data to a column-oriented table,
+
+tbl = Arrow.Table(fnm);
+typeof(tbl)
+
+# which is similar to a `DataFrame`.
+
+using DataFrames
+describe(DataFrame(tbl))
+
+#=
+Because the columns are all stored as 64-bit floating-point numbers, this arrow file can be read in R
+
+```R
+> library(arrow)
+
+Attaching package: ‘arrow’
+
+The following object is masked from ‘package:utils’:
+
+    timestamp
+
+> simdat <- read_feather("./data/simulations/a=12.25_b=240.16_σ=8.55.arrow")
+> library(tibble)
+> glimpse(simdat)
+Rows: 50,000
+Columns: 3
+$ slope     <dbl> 12.38975, 12.29462, 12.76479, 12.30775, 13.51588, 11.22870,…
+$ intercept <dbl> 235.6208, 242.3419, 238.2172, 240.5549, 239.7041, 240.9386,…
+$ `s²`      <dbl> 116.64295, 20.87278, 94.90334, 60.11505, 70.39227, 65.19233…
+```
+=#


### PR DESCRIPTION
- Convert the .jmd notebook to a .jl notebook for the `Literate.jl` package.
- Still working on getting the markdown created from `Literate.markdown` converted to HTML using the Markdown or Documenter package.